### PR TITLE
Fixed abstract content detection

### DIFF
--- a/extension/cite-d-lite.js
+++ b/extension/cite-d-lite.js
@@ -721,16 +721,10 @@ var Abstract = {
 			"delta": 0.5
 		};
 
-		var abstracttext = document.getElementsByTagName('abstracttext');
-		if(abstracttext.length > 1) {
-			abstracttext = abstracttext[0].parentNode.parentNode;
-		}
-		else {
-			abstracttext = abstracttext[0];
-		}
+		var abstracttext = document.getElementsByClassName('abstr')[0].children[1];
 
-	    var inputToSummarize = $.trim(abstracttext.innerHTML);
-	    if (inputToSummarize.length !== 0) {
+		var inputToSummarize = $.trim(abstracttext.innerText);
+		if (inputToSummarize.length !== 0) {
 			// Invoke the summarizer algo.
 			var sentences = Summarizer.Utility.getSentences(inputToSummarize);
 			var graph = Summarizer.Utility.makeGraph(sentences);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Cite-D-Lite",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Ma'ayan Lab",
 	
 	"icons":{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esther",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "chromeextension",
   "main": "main.js",
   "dependencies": {

--- a/src/Abstract.js
+++ b/src/Abstract.js
@@ -6,16 +6,10 @@ var Abstract = {
 			"delta": 0.5
 		};
 
-		var abstracttext = document.getElementsByTagName('abstracttext');
-		if(abstracttext.length > 1) {
-			abstracttext = abstracttext[0].parentNode.parentNode;
-		}
-		else {
-			abstracttext = abstracttext[0];
-		}
+		var abstracttext = document.getElementsByClassName('abstr')[0].children[1];
 
-	    var inputToSummarize = $.trim(abstracttext.innerHTML);
-	    if (inputToSummarize.length !== 0) {
+		var inputToSummarize = $.trim(abstracttext.innerText);
+		if (inputToSummarize.length !== 0) {
 			// Invoke the summarizer algo.
 			var sentences = Summarizer.Utility.getSentences(inputToSummarize);
 			var graph = Summarizer.Utility.makeGraph(sentences);


### PR DESCRIPTION
This change should be merged and the extension redeployed.

The code to parse the abstract from the page's HTML no longer works, the name of the surrounding tags has changed.  This update makes the code reflect the current working version of the PubMed site.